### PR TITLE
Proof of concept to add a visual coordinates grid

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -26,6 +26,9 @@
   min-width: 400px;
   height: 100vh;
   justify-content: center;
+  /* TODO! */
+  padding-right: 20px;
+  padding-bottom: 50px;
 }
 
 .viewer-wrapper .svg-viewer {
@@ -64,7 +67,7 @@ code {
   padding: 0;
 }
 
-.cards li + li {
+.cards li+li {
   padding-top: 10px;
 }
 
@@ -93,6 +96,7 @@ code {
 }
 
 /* Give space to see the svg below */
+
 @media all and (max-width: 850px) {
   .cards {
     margin-bottom: calc(100vh - 80px);
@@ -100,8 +104,7 @@ code {
 }
 
 @media all and (max-width: 450px) {
-  .cards,
-  .sticky {
+  .cards, .sticky {
     width: 100vw;
     min-width: 0;
   }
@@ -133,4 +136,25 @@ code {
   text-decoration: none;
   margin-left: 50%;
   transform: translate(-50%, 0);
+}
+
+/* TODO! */
+
+.grid-main {
+  stroke: #ccc;
+}
+
+.grid-sub-x {
+  stroke: #ccc;
+}
+
+.grid-sub-y {
+  stroke: #ccc;
+}
+
+.grid-label {
+  fill: #666;
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 14px;
+  font-weight: 600;
 }

--- a/src/SVGViewer.tsx
+++ b/src/SVGViewer.tsx
@@ -570,6 +570,7 @@ function SVGViewer({
       return prev;
     },
     {
+      grid: [] as React.ReactNode[],
       elems: [] as React.ReactNode[],
       overlay: [] as React.ReactNode[],
       current: { x: 0, y: 0 },
@@ -607,8 +608,82 @@ function SVGViewer({
     }
   }
 
+  const gridDeltaX = bounds[2] - bounds[0] - 50;
+  const gridDeltaY = bounds[3] - bounds[1] - 50;
+  const gridStep = 20; // TODO!
+  const gridIntervalsY = gridDeltaX / gridStep; // TODO!
+  const gridIntervalsX = gridDeltaY / gridStep; // TODO!
+
+  // main X axis
+  data.grid.push(
+    <line
+      key={'grid-main-x'}
+      x1={0}
+      y1={0}
+      x2={gridDeltaX}
+      y2={0}
+      className="grid-main"
+      strokeWidth={stroke / 1}
+    />
+  );
+  // main Y axis
+  data.grid.push([
+    <line
+      key={'grid-main-y'}
+      x1={0}
+      y1={0}
+      x2={0}
+      y2={gridDeltaY}
+      className="grid-main"
+      strokeWidth={stroke / 1}
+    />,
+    <text x={-20} y={-10} className="grid-label">(0,0)</text>
+  ]);
+  // sub X axis
+  for (let i = 1; i < gridIntervalsX; i++) {
+    const currY = i * gridStep;
+    data.grid.push(
+      <line
+        key={`grid-sub-x${i}`}
+        x1={0}
+        y1={currY}
+        x2={gridDeltaX}
+        y2={currY}
+        className="grid-sub-x"
+        strokeWidth={stroke / 5}
+        strokeDasharray={i % 5 === 0 ? 0 : gridStep / 10}
+      />
+    );
+    if (i % 5 === 0) {
+      data.grid.push(
+        <text x={-20} y={currY} className="grid-label">{currY}</text>
+      );
+    }
+  }
+  for (let i = 1; i < gridIntervalsY; i++) {
+    const currX = i * gridStep;
+    data.grid.push(
+      <line
+        key={`grid-sub-y${i}`}
+        x1={currX}
+        y1={0}
+        x2={currX}
+        y2={gridDeltaY}
+        className="grid-sub-y"
+        strokeWidth={stroke / 5}
+        strokeDasharray={i % 5 === 0 ? 0 : gridStep / 10}
+      />
+    );
+    if (i % 5 === 0) {
+      data.grid.push(
+        <text x={currX} y={-10} className="grid-label">{currX}</text>
+      );
+    }
+  }
+
   return (
     <svg className="svg-viewer" viewBox={bounds.join(" ")}>
+      {data.grid}
       {data.elems}
       {data.overlay}
     </svg>


### PR DESCRIPTION
This is (super-raw) proof of concept that I have prepared, to add a grid of coordinates below the SVG "elements", to help visualize (and understand) the relation between the numbers in the path and the coordinates system of the SVG, and discuss if proceed from here.

This is what it looks like (again, a general idea):
<img width="1789" alt="screenshot_4472" src="https://user-images.githubusercontent.com/686239/80758873-40caa400-8b2e-11ea-88f5-23585b0da208.png">

I have opened this PR to see if makes sense also for you, and in that case discuss what is the best way to implement it in the rendered SVG. eg. the axis should cover also the negative coordinates? should we add a coordinate indicator on hover? other things that can help visualize the relation between `M 140,20` and the fact that this refers to the coordinates (x=140,y=20)? should I introduce an helper to calculate a "scale-factor" that automatically adjusts the entire grid, based on the min/max X/Y values?

(of course, in that case, I'll write proper code, and use the `style()` function to style the lines) don't worry. this was a quick hack done before dinner)