### PR TITLE
Improved ViewBox Calculation (Margin and Centering)

### DIFF
--- a/src/SVGViewer.tsx
+++ b/src/SVGViewer.tsx
@@ -751,8 +751,8 @@ function SVGViewer({
   const bounds = [
     pathData.bounds.minX - margin,
     pathData.bounds.minY - margin,
-    pathData.bounds.maxX + margin,
-    pathData.bounds.maxY + margin,
+    pathData.bounds.maxX + margin * 2,
+    pathData.bounds.maxY + margin * 2,
   ];
 
   const width = bounds[2] - bounds[0];

--- a/src/SVGViewer.tsx
+++ b/src/SVGViewer.tsx
@@ -748,15 +748,15 @@ function SVGViewer({
 
   const margin = stroke * 10;
 
-  const bounds = [
+  const viewBox = [
     pathData.bounds.minX - margin,
     pathData.bounds.minY - margin,
-    pathData.bounds.maxX + margin * 2,
-    pathData.bounds.maxY + margin * 2,
+    pathData.bounds.maxX - pathData.bounds.minX + margin * 2,
+    pathData.bounds.maxY - pathData.bounds.minY + margin * 2,
   ];
 
-  const width = bounds[2] - bounds[0];
-  const height = bounds[3] - bounds[1];
+  const width = viewBox[2];
+  const height = viewBox[3];
 
   if (windowSize.width && windowSize.height) {
     const containerSize = {
@@ -764,20 +764,22 @@ function SVGViewer({
       height: windowSize.height,
     };
     if (width / height > containerSize.width / containerSize.height) {
-      const left =
+      // portrait
+      const additionalViewBoxHeight =
         (width / height - containerSize.width / containerSize.height) * height;
-      bounds[1] -= left / 2;
-      bounds[3] += left / 2;
+      viewBox[1] -= additionalViewBoxHeight / 2;
+      viewBox[3] += additionalViewBoxHeight;
     } else {
-      const left =
+      // landscape
+      const additionalViewBoxWidth =
         (containerSize.width / containerSize.height - width / height) * width;
-      bounds[0] -= left / 2;
-      bounds[2] += left / 2;
+      viewBox[0] -= additionalViewBoxWidth / 2;
+      viewBox[2] += additionalViewBoxWidth;
     }
   }
 
   return (
-    <svg className="svg-viewer" viewBox={bounds.join(" ")}>
+    <svg className="svg-viewer" viewBox={viewBox.join(" ")}>
       {data.elems}
       {data.overlay}
     </svg>


### PR DESCRIPTION
# Improved ViewBox Calculation

## Bugfix: Right and bottom Margin missing

This can be observed using a simple square (`M0,0 L10,0 L10,10 L0,10z`).

The SVG ViewBox is defined as `"min-x min-y width height"`, but in code here it was filled with `"min-x min-y max-x max-y"`.
Adding the Margin `*2` to `viewBox[2]` and `[3]` fixes this.

Before|After
------|-----
![viewbox-margin-before](https://user-images.githubusercontent.com/34600077/181263838-a39951fe-baba-43b6-8138-20e4566a8b11.png)|![viewbox-margin-after](https://user-images.githubusercontent.com/34600077/181263888-153a8aac-b733-4238-b25d-c39dcc2236b7.png)

## Bugfix: Improved Centering of path in viewer

There are two ways, where the displayed path is not centered in the viewer. (Both of them also come from the viewBox calculation)

### 1. the aspect ratio of the viewer part is not close to 1

When calculating the additional margin for landscape/portrait, the width/height must be increased with the full additional margin instead of half.

Before|After
------|-----
![aspect-ratio-before](https://user-images.githubusercontent.com/34600077/181263985-d327b5b9-4c54-4407-8bb9-fb15fcc385b9.png)|![aspect-ratio-after](https://user-images.githubusercontent.com/34600077/181264002-83250e9a-7c70-461b-b6ce-ec680ce461db.png)

### 2. when the min-x or min-y are not 0

Example-Path: `M10,0 L20,0 L20,10 L10,10z`

The width of the viewBox must account for the min-x and min-y.

Before|After
------|-----
![minx-miny-not-zero-before](https://user-images.githubusercontent.com/34600077/181264098-149e8dd5-6c06-4607-bddb-b476054455ec.png)|![minx-miny-not-zero-after](https://user-images.githubusercontent.com/34600077/181264110-6cb75399-e89d-4406-915e-992e878bcf2f.png)

## Conclusion

All of this results in an improved positioning in the path viewer.

For example the curve greatly benefits from this:

Before|After
------|-----
![curve-before](https://user-images.githubusercontent.com/34600077/181264193-1cc1d2f9-34f7-41af-b7c6-3aac7d6b5cbd.png)|![curve-after](https://user-images.githubusercontent.com/34600077/181264225-34ff268a-3354-4f6d-bb9e-c6d9c2d40cc8.png)

